### PR TITLE
Improve set additional claims method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 0.1.1
+
+- Updating `JWTBuilder#set_additional_claims` method to not mutate the input `params` hash.
+
 # 0.1.0
 
 First version released!

--- a/lib/vonage-jwt/jwt_builder.rb
+++ b/lib/vonage-jwt/jwt_builder.rb
@@ -91,7 +91,7 @@ module Vonage
     end
 
     def set_additional_claims(params)
-      params.delete_if {|k,v| [:application_id, :private_key, :jti, :nbf, :ttl, :exp, :alg, :paths, :subject].include?(k) }
+      params.dup.delete_if {|k,v| [:application_id, :private_key, :jti, :nbf, :ttl, :exp, :alg, :paths, :subject].include?(k) }
     end
 
     def set_exp

--- a/lib/vonage-jwt/version.rb
+++ b/lib/vonage-jwt/version.rb
@@ -2,6 +2,6 @@
 
 module Vonage
   class JWT
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end

--- a/spec/vonage-jwt/jwt_builder_spec.rb
+++ b/spec/vonage-jwt/jwt_builder_spec.rb
@@ -229,13 +229,14 @@ describe Vonage::JWTBuilder do
 
   context 'with additional private claims' do
     before :each do
-      @builder = Vonage::JWTBuilder.new(
+      @claims = {
         application_id: '123456789',
         private_key: './spec/vonage-jwt/private_key.txt',
         subject: 'ExampleApp',
         foo: 'bar',
         baz: 'qux'
-      )
+      }
+      @builder = Vonage::JWTBuilder.new(@claims)
       token = @builder.jwt.generate
       @decoded_token = JWT.decode(token, nil, nil, { algorithm: 'RS256' })
     end
@@ -247,6 +248,10 @@ describe Vonage::JWTBuilder do
     it 'generates a JWT string with the data provided' do
       expect(@decoded_token.first['foo']).to eql('bar')
       expect(@decoded_token.first['baz']).to eql('qux')
+    end
+
+    it 'does not mutate the original params hash' do
+      expect(@decoded_token.first).to match(hash_including(@claims))
     end
   end
 end

--- a/spec/vonage-jwt/jwt_builder_spec.rb
+++ b/spec/vonage-jwt/jwt_builder_spec.rb
@@ -251,7 +251,13 @@ describe Vonage::JWTBuilder do
     end
 
     it 'does not mutate the original params hash' do
-      expect(@decoded_token.first).to match(hash_including(@claims))
+      expect(@claims).to match(hash_including(
+        application_id: '123456789',
+        private_key: './spec/vonage-jwt/private_key.txt',
+        subject: 'ExampleApp',
+        foo: 'bar',
+        baz: 'qux'
+      ))
     end
   end
 end


### PR DESCRIPTION
- Updating `JWTBuilder#set_additional_claims` method to not mutate the input `params` hash.