### PR TITLE
Reducing minimum required Ruby version

### DIFF
--- a/vonage-jwt.gemspec
+++ b/vonage-jwt.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = 'Vonage JWT Generator for Ruby'
   s.summary = 'This is the Ruby client library to generate Vonage JSON Web Tokens (JWTs).'
   s.files = Dir.glob('lib/**/*.rb') + %w[LICENSE.txt README.md vonage-jwt.gemspec]
-  s.required_ruby_version = '>= 2.7.0'
+  s.required_ruby_version = '>= 2.5.0'
   s.add_dependency('jwt', '~> 2')
   s.require_path = 'lib'
   s.metadata = {


### PR DESCRIPTION
* Updates the `gemspec` to reduce the min required Ruby version for `2.7` to `2.5`. This is to keep it in line with the min version for the [vonage-ruby-sdk](https://github.com/Vonage/vonage-ruby-sdk).