### PR TITLE
Removing default sub field and value from payload

### DIFF
--- a/lib/vonage-jwt/jwt.rb
+++ b/lib/vonage-jwt/jwt.rb
@@ -21,10 +21,10 @@ module Vonage
         iat: iat,
         jti: generator.jti,
         exp: generator.exp || iat + generator.ttl,
-        sub: generator.subject,
         application_id: generator.application_id
       }
       hash.merge!(generator.paths) if generator.paths
+      hash.merge!(sub: generator.subject) if generator.subject
       hash.merge!(nbf: generator.nbf) if generator.nbf
       hash.merge!(generator.additional_claims) if !generator.additional_claims.empty?
       hash

--- a/lib/vonage-jwt/jwt_builder.rb
+++ b/lib/vonage-jwt/jwt_builder.rb
@@ -54,7 +54,7 @@ module Vonage
       @exp = params.fetch(:exp, nil)
       @alg = params.fetch(:alg, 'RS256')
       @paths = params.fetch(:paths, nil)
-      @subject = params.fetch(:subject, 'Subject')
+      @subject = params.fetch(:subject, nil)
       @additional_claims = set_additional_claims(params)
       @jwt = Vonage::JWT.new(generator: self)
 


### PR DESCRIPTION
This PR:

- removes the default value for the `@subject` ivar, in `Vonage::JWTBuilder` and also updates the implementation of `Vonage::JWT` so that a `sub` field is not set if `@subject` has no value.

Motivation: to fix an issue with the [User](https://developer.vonage.com/en/api/application.v2#User) endpoints in the [Application](https://developer.vonage.com/en/api/application.v2) API, whereby an Auth error was received if `sub` was provided as part of the JWT.