### PR TITLE
Release 0.1.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 0.1.3
+
+-  Removing default sub field and value from payload. See [#3](https://github.com/Vonage/vonage-jwt-ruby/pull/3)
+
 # 0.1.2
 
 - Reducing minimum required Ruby version from `2.7` to `2.5`. See [#2](https://github.com/Vonage/vonage-jwt-ruby/pull/2)

--- a/lib/vonage-jwt/version.rb
+++ b/lib/vonage-jwt/version.rb
@@ -2,6 +2,6 @@
 
 module Vonage
   class JWT
-    VERSION = '0.1.2'
+    VERSION = '0.1.3'
   end
 end


### PR DESCRIPTION
This PR:

- Bumps the patch version to `0.1.3`
- Updates the changelog