### PR TITLE
DEVX-7707: Add decode and verify signature functionality to the library

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 0.2.0
+
+-  Adds `decode` and `verify_signature` methods to the `JWT` class. See [#5](https://github.com/Vonage/vonage-jwt-ruby/pull/5)
+
 # 0.1.3
 
 -  Removing default sub field and value from payload. See [#3](https://github.com/Vonage/vonage-jwt-ruby/pull/3)

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ Alternatively you can clone the repository:
 
 ## Usage
 
+### Generating a JWT
+
 By default the Vonage JWT generator creates a short lived JWT (15 minutes) per request.
 To generate a long lived JWT for multiple requests, specify a longer value in the `exp`
-parameter during initialization. 
+parameter during initialization.
 
 Example with no custom configuration:
 
@@ -51,16 +53,38 @@ Example providing custom configuration options:
         "/messages": {
           "methods": ["POST", "GET"],
           "filters": {
-            "from": "447977271009"  
-          }     
-        }  
-      }   
+            "from": "447977271009"
+          }
+        }
+      }
     }
   },
   subject: 'My_Custom_Subject'
 )
 @token = @builder.jwt.generate
 ```
+
+### Decoding a JWT
+
+You can decode a JWT like so:
+
+```ruby
+Vonage::JWT.decode(token, nil, false)
+```
+
+where `token` is the JWT that you want to decode. The `Vonage::JWT::decode` method is essentially just a wrapper around the `ruby-jwt` library method of the same name, and usage is identical to what is [documented for that library](https://github.com/jwt/ruby-jwt#algorithms-and-usage).
+
+### Verifying a Signature
+
+For JWTs that are signed, you can verify a JWT signature like so:
+
+```ruby
+Vonage::JWT.verify_signature(token, signature_secret, algorithm)
+```
+
+where `token` is the signed JWT, `signature_secret` is the secret or key required by whichever algorithm was used to sign the JWT, and `algorithm` is a string indicating the algorithm that was used to sign the JWT (e.g. `'HS256'`, `'RS256'`, etc)
+
+The method will return `true` if the signature is verified and `false` if it is not.
 
 ## Documentation
 

--- a/lib/vonage-jwt/jwt.rb
+++ b/lib/vonage-jwt/jwt.rb
@@ -29,5 +29,18 @@ module Vonage
       hash.merge!(generator.additional_claims) if !generator.additional_claims.empty?
       hash
     end
+
+    def self.decode(token, secret = nil, verify = true, opts = {}, &block)
+      ::JWT.decode(token, secret, verify, opts, &block)
+    end
+
+    def self.verify_signature(token, signature_secret, algorithm)
+      begin
+        decode(token, signature_secret, true, {algorithm: algorithm})
+        return true
+      rescue ::JWT::VerificationError
+        return false
+      end
+    end
   end
 end

--- a/lib/vonage-jwt/version.rb
+++ b/lib/vonage-jwt/version.rb
@@ -2,6 +2,6 @@
 
 module Vonage
   class JWT
-    VERSION = '0.1.3'
+    VERSION = '0.2.0'
   end
 end

--- a/spec/vonage-jwt/jwt_spec.rb
+++ b/spec/vonage-jwt/jwt_spec.rb
@@ -1,0 +1,54 @@
+require_relative 'spec_helper'
+
+describe Vonage::JWT do
+  let(:token) { "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1ODc0OTQ5NjIsImp0aSI6ImM1YmE4ZjI0LTFhMTQtNGMxMC1iZmRmLTNmYmU4Y2U1MTFiNSIsImlzcyI6IlZvbmFnZSIsInBheWxvYWRfaGFzaCI6ImQ2YzBlNzRiNTg1N2RmMjBlM2I3ZTUxYjMwYzBjMmE0MGVjNzNhNzc4NzliNmYwNzRkZGM3YTIzMTdkZDAzMWIiLCJhcGlfa2V5IjoiYTFiMmMzZCIsImFwcGxpY2F0aW9uX2lkIjoiYWFhYWFhYWEtYmJiYi1jY2NjLWRkZGQtMDEyMzQ1Njc4OWFiIn0.JQRKi1d0SQitmjPINfTWMpt3XZkGsLbD7EjCdXoNSbk" }
+
+  describe '.decode' do
+    let(:decoded_token) do
+      [{"iat"=>1587494962,
+        "jti"=>"c5ba8f24-1a14-4c10-bfdf-3fbe8ce511b5",
+        "iss"=>"Vonage",
+        "payload_hash"=>"d6c0e74b5857df20e3b7e51b30c0c2a40ec73a77879b6f074ddc7a2317dd031b",
+        "api_key"=>"a1b2c3d",
+        "application_id"=>"aaaaaaaa-bbbb-cccc-dddd-0123456789ab"},
+       {"alg"=>"HS256", "typ"=>"JWT"}]
+    end
+
+    it 'correctly decodes the token payload' do
+      expect(Vonage::JWT.decode(token, nil, false).first).to match(
+        hash_including(
+          {
+            "iat"=>1587494962,
+            "jti"=>"c5ba8f24-1a14-4c10-bfdf-3fbe8ce511b5",
+            "iss"=>"Vonage",
+            "payload_hash"=>"d6c0e74b5857df20e3b7e51b30c0c2a40ec73a77879b6f074ddc7a2317dd031b",
+            "api_key"=>"a1b2c3d",
+            "application_id"=>"aaaaaaaa-bbbb-cccc-dddd-0123456789ab"
+          }
+        )
+      )
+    end
+
+    it 'correctly decodes the token header' do
+      expect(Vonage::JWT.decode(token, nil, false).last).to match(hash_including({"alg"=>"HS256", "typ"=>"JWT"}))
+    end
+  end
+
+  describe '.verify_signature' do
+    context 'with a valid signature secret' do
+      let(:signature_secret) { "ZYtdTtGV3BCFN7tWmOWr1md66XsquMggr4W2cTtXtcPgfnI0Xw" }
+
+      it 'returns true' do
+        expect(Vonage::JWT.verify_signature(token, signature_secret, 'HS256')).to be true
+      end
+    end
+
+    context 'with an invalid signature secret' do
+      let(:signature_secret) { "ZYtdTtGV3BCFN7tWmOWr1md66XsquMggr4W2cTtXtcPgf55555" }
+
+      it 'returns false' do
+        expect(Vonage::JWT.verify_signature(token, signature_secret, 'HS256')).to be false
+      end
+    end
+  end
+end

--- a/spec/vonage-jwt/jwt_spec.rb
+++ b/spec/vonage-jwt/jwt_spec.rb
@@ -4,16 +4,6 @@ describe Vonage::JWT do
   let(:token) { "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1ODc0OTQ5NjIsImp0aSI6ImM1YmE4ZjI0LTFhMTQtNGMxMC1iZmRmLTNmYmU4Y2U1MTFiNSIsImlzcyI6IlZvbmFnZSIsInBheWxvYWRfaGFzaCI6ImQ2YzBlNzRiNTg1N2RmMjBlM2I3ZTUxYjMwYzBjMmE0MGVjNzNhNzc4NzliNmYwNzRkZGM3YTIzMTdkZDAzMWIiLCJhcGlfa2V5IjoiYTFiMmMzZCIsImFwcGxpY2F0aW9uX2lkIjoiYWFhYWFhYWEtYmJiYi1jY2NjLWRkZGQtMDEyMzQ1Njc4OWFiIn0.JQRKi1d0SQitmjPINfTWMpt3XZkGsLbD7EjCdXoNSbk" }
 
   describe '.decode' do
-    let(:decoded_token) do
-      [{"iat"=>1587494962,
-        "jti"=>"c5ba8f24-1a14-4c10-bfdf-3fbe8ce511b5",
-        "iss"=>"Vonage",
-        "payload_hash"=>"d6c0e74b5857df20e3b7e51b30c0c2a40ec73a77879b6f074ddc7a2317dd031b",
-        "api_key"=>"a1b2c3d",
-        "application_id"=>"aaaaaaaa-bbbb-cccc-dddd-0123456789ab"},
-       {"alg"=>"HS256", "typ"=>"JWT"}]
-    end
-
     it 'correctly decodes the token payload' do
       expect(Vonage::JWT.decode(token, nil, false).first).to match(
         hash_including(


### PR DESCRIPTION
This PR:

- Adds `decode` and `verify_signature` methods to to the `JWT` class.
- The motivation behind these changes is to expose a simple way for users to verify a signature for a webhook received from the Vonage APIs that provide signed JWTs in theire requests headers (e.g. the Messages API and Voice API).