### PR TITLE
chore: Prepare Release 0.2.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 0.2.1
+
+-  Updates the `gemspec` for the `ruby-jwt` dependency. See [#14](https://github.com/Vonage/vonage-jwt-ruby/pull/14)
+
 # 0.2.0
 
 -  Adds `decode` and `verify_signature` methods to the `JWT` class. See [#5](https://github.com/Vonage/vonage-jwt-ruby/pull/5)

--- a/lib/vonage-jwt/version.rb
+++ b/lib/vonage-jwt/version.rb
@@ -2,6 +2,6 @@
 
 module Vonage
   class JWT
-    VERSION = '0.2.0'
+    VERSION = '0.2.1'
   end
 end


### PR DESCRIPTION
This PR prepares for release `v0.2.1`. Specifically it:

- Bumps the patch version number
- Updates the Changelog